### PR TITLE
Wyróżnienie wierszy tabeli klasyfikacji końcowej

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -72,6 +72,17 @@ Miejsca w tabeli końcowej dla drużyn zdefiniowanych jako kończące rozgrywki 
 Program nie potrafi ich rozstrzygać samodzielnie remisów podczas pobierania wyników z bazy danych. Dla listy teamów pobranej ze strony wyników, zachowana jest kolejność na stronie (więc remisy rozstrzygnięte przez Teamy przed wygenerowaniem wyników).
 
 
+Ustawienia stylów klasyfikacji końcowej
+---------------------------------------
+
+Sekcja `"position_styles"` pozwala wyróżnić określone pozycje tabeli klasyfikacji końcowej, nadając im dowolnie zdefiniowaną klasę CSS.
+
+Jest to tablica obiektów o następujących składowych:
+ - `"class"` - nazwa klasy CSS ustawianej na odpowiednich elementach `<tr>` tabeli klasyfikacji
+ - `"positions"` - tablica liczb naturalnych określających pozycje tabeli, do których klasa CSS jest dodawana
+ - `"caption"` - opcjonalny opis wyświetlany w legendzie pod klasyfikacją końcową
+
+
 Ustawienia drabinki
 -------------------
 

--- a/jfr_playoff/generator.py
+++ b/jfr_playoff/generator.py
@@ -11,6 +11,9 @@ class PlayoffGenerator(object):
         self.canvas = {}
         if settings.has_section('canvas'):
             self.canvas = settings.get('canvas')
+        self.leaderboard_classes = {}
+        if settings.has_section('position_styles'):
+            self.leaderboard_classes = settings.get('position_styles')
 
     def generate_content(self):
         return p_temp.PAGE % (
@@ -119,6 +122,13 @@ class PlayoffGenerator(object):
             grid_boxes
         )
 
+    def get_leaderboard_row_class(self, position):
+        classes = []
+        for style in self.leaderboard_classes:
+            if position in style['positions']:
+                classes.append(style['class'])
+        return ' '.join(classes)
+
     def get_leaderboard_table(self):
         leaderboard = self.data.fill_leaderboard()
         if len([t for t in leaderboard if t is not None]) == 0:
@@ -127,6 +137,7 @@ class PlayoffGenerator(object):
         rows = ''
         for team in leaderboard:
             rows += p_temp.LEADERBOARD_ROW % (
+                self.get_leaderboard_row_class(position),
                 position, self.get_flag(team), team or '')
             position += 1
         html = p_temp.LEADERBOARD.decode('utf8') % (rows)

--- a/jfr_playoff/generator.py
+++ b/jfr_playoff/generator.py
@@ -16,6 +16,11 @@ class PlayoffGenerator(object):
             self.leaderboard_classes = settings.get('position_styles')
 
     def generate_content(self):
+        match_grid = self.get_match_grid(
+            self.data.get_dimensions(),
+            self.data.generate_phases(),
+            self.data.fill_match_info())
+        leaderboard_table = self.get_leaderboard_table()
         return p_temp.PAGE % (
             p_temp.PAGE_HEAD % (
                 p_temp.PAGE_HEAD_REFRESH % (
@@ -24,12 +29,10 @@ class PlayoffGenerator(object):
                 self.page['title']),
             p_temp.PAGE_BODY % (
                 self.page['logoh'],
-                self.get_match_grid(
-                    self.data.get_dimensions(),
-                    self.data.generate_phases(),
-                    self.data.fill_match_info()),
+                match_grid,
                 self.get_swiss_links(),
-                self.get_leaderboard_table(),
+                leaderboard_table,
+                self.get_leaderboard_caption_table() if leaderboard_table else '',
                 p_temp.PAGE_BODY_FOOTER.decode('utf8') % (
                     datetime.now().strftime('%Y-%m-%d o %H:%M:%S'))))
 
@@ -128,6 +131,14 @@ class PlayoffGenerator(object):
             if position in style['positions']:
                 classes.append(style['class'])
         return ' '.join(classes)
+
+    def get_leaderboard_caption_table(self):
+        rows = ''
+        for style in self.leaderboard_classes:
+            if 'caption' in style:
+                rows += p_temp.LEADERBOARD_CAPTION_TABLE_ROW % (
+                    style['class'], style['caption'])
+        return p_temp.LEADERBOARD_CAPTION_TABLE % (rows) if rows else ''
 
     def get_leaderboard_table(self):
         leaderboard = self.data.fill_leaderboard()

--- a/jfr_playoff/template.py
+++ b/jfr_playoff/template.py
@@ -108,6 +108,22 @@ LEADERBOARD_ROW_FLAG = '''
 <img class="fl" src="images/%s" />
 '''
 
+LEADERBOARD_CAPTION_TABLE = '''
+<table class="caption_table" border="0" cellspacing="0">
+<tr><td class="e">&nbsp;</td></tr>
+<tr><td class="bdnl12" align="center"><b>&nbsp;LEGENDA&nbsp;</b></td></tr>
+%s
+</table>
+'''
+
+LEADERBOARD_CAPTION_TABLE_ROW = '''
+<tr class="%s">
+<td class="bd1">
+&nbsp;%s&nbsp;
+</td>
+</tr>
+'''
+
 PAGE_HEAD = '''
 <meta http-equiv="Pragma" content="no-cache" />
 <meta http-equiv="Cache-Control" content="no-cache" />
@@ -132,6 +148,7 @@ PAGE_BODY = '''
 <p>
 %s
 </p>
+%s
 %s
 %s
 '''

--- a/jfr_playoff/template.py
+++ b/jfr_playoff/template.py
@@ -96,7 +96,7 @@ LEADERBOARD = '''
 '''
 
 LEADERBOARD_ROW = '''
-<tr>
+<tr class="%s">
 <td class="bdc1">%d</td>
 <td class="bd">
 &nbsp;%s&nbsp;&nbsp;%s&nbsp;


### PR DESCRIPTION
Realizacja #23.

Można zdefiniować dowolne klasy CSS dla dowolnych pozycji tabeli + opcjonalny opis, wyświetlany w legendzie.

Efekt wygląda tak:
![image](https://user-images.githubusercontent.com/3368944/39242297-e157d54e-4889-11e8-8ed8-f45de01cdde2.png)

Po scaleniu zmian do `master`, konfiguracja dla lig centralnych znajduje się w gałęzi [`leaderboard_classes`](https://github.com/michzimny/pzbs-liga-playoff/tree/leaderboard_classes), a `kolorki.css` zmodyfikowałem o, tak:
```
tr.winner > td,
tr.promotion > td {
	background: #dfd;
}
tr.loser > td,
tr.relegation > td {
	background: #fee;
}

tr.repechage > td {
	background: #ffd;
}
```